### PR TITLE
fix define* check-syntax arrows within compatibility/package

### DIFF
--- a/compatibility-lib/compatibility/package.rkt
+++ b/compatibility-lib/compatibility/package.rkt
@@ -61,7 +61,7 @@
                              stx
                              id))
        (define (accumulate exports forms)
-         (define intro (make-syntax-introducer))
+         (define intro (make-syntax-introducer #t))
          #`(drive-top-level
             (accumulate-package #,id #,(intro id) #,(intro id) #f #,stx
                                 #,exports
@@ -102,7 +102,7 @@
           (let* ([star? (or (free-identifier=? #'def #'-define*-values)
                             (free-identifier=? #'def #'-define*-syntaxes))]
                  [next-intro (if star?
-                                 (make-syntax-introducer)
+                                 (make-syntax-introducer #t)
                                  (lambda (s) s))]
                  [exp-form
                   (with-syntax ([(new-def-id ...) (if star?


### PR DESCRIPTION
So that the check-syntax arrows work in programs like this:
```racket
#lang racket
(require compatibility/package)
(define-package pkg
  (x)
  (define* x 4) ; from this x
  (define* x (+ x 1))) ; to the second x here
```
This also fixes the check-syntax arrows in @elibarzilay's `#lang pl broken`, which desugars into this for its sequential scoping behavior.