### PR TITLE
Add .travis.yml (WIP?)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,17 @@ env:
 - PATH=~/racket/bin:$PATH
 
 before_install:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
+#- "export DISPLAY=:99.0"
+#- "sh -e /etc/init.d/xvfb start"
 #- curl -L -o installer.sh http://plt.eecs.northwestern.edu/snapshots/current/installers/racket-test-current-x86_64-linux-precise.sh
 - curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-precise.sh
 - sh installer.sh --in-place --dest ~/racket/
 - racket -v
 
 install:
+- raco pkg install --auto -i --no-setup --skip-installed racket-test
+- raco setup --pkgs racket-test
+
 - raco pkg install --auto -i --no-setup --skip-installed compatibility-test
 - racket -l- pkg/dirs-catalog --link --check-metadata pkgs-catalog .
 - echo file://`pwd`/pkgs-catalog/ > catalog-config.txt
@@ -21,11 +24,12 @@ install:
 - raco pkg config --set catalogs `cat catalog-config.txt`
 - raco pkg update -i --auto --no-setup compatibility-lib/ compatibility-test/
 - raco setup --pkgs compatibility compatibility-lib compatibility-test
-- ls $HOME/.racket/download-cache
+
+- ls -1 ~/.racket/download-cache
 
 script:
 - raco test -e -l tests/mzlib/test
 - raco test -e -l tests/racket/package
-- raco test -e -l tests/racket/package-arrow
+- raco test -e -l tests/racket/package-arrows
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: false
+
+language: c
+
+env:
+- PATH=~/racket/bin:$PATH
+
+before_install:
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
+#- curl -L -o installer.sh http://plt.eecs.northwestern.edu/snapshots/current/installers/racket-test-current-x86_64-linux-precise.sh
+- curl -L -o installer.sh http://www.cs.utah.edu/plt/snapshots/current/installers/racket-current-x86_64-linux-precise.sh
+- sh installer.sh --in-place --dest ~/racket/
+- racket -v
+
+install:
+- raco pkg install --auto -i --no-setup --skip-installed compatibility-test
+- racket -l- pkg/dirs-catalog --link --check-metadata pkgs-catalog .
+- echo file://`pwd`/pkgs-catalog/ > catalog-config.txt
+- raco pkg config catalogs >> catalog-config.txt
+- raco pkg config --set catalogs `cat catalog-config.txt`
+- raco pkg update -i --auto --no-setup compatibility-lib/ compatibility-test/
+- raco setup --pkgs compatibility compatibility-lib compatibility-test
+- ls $HOME/.racket/download-cache
+
+script:
+- raco test -e -l tests/mzlib/test
+- raco test -e -l tests/racket/package
+- raco test -e -l tests/racket/package-arrow
+
+after_script:


### PR DESCRIPTION
I copied the `.travis.yml` file and made the obvious changes. A similar script works in my machine but I get an error in travis [compatibility/#L667-L670](https://travis-ci.org/gus-massa/compatibility/builds/544816867#L667-L670). 

    raco setup: 1 making: <pkgs>/net-test/tests/net
    instantiate: unknown module
      module name: #<resolved-module-path:"/home/travis/racket/collects/syntax/moddep.rkt">
      compilation context...:

It is strange because I can see the file `moddep.rkt`. I tried a few changes, but I was no able to fix this. 

I probably need some help from @samth here.
