### PR TITLE
Update mlist.rkt

### DIFF
--- a/compatibility-lib/compatibility/mlist.rkt
+++ b/compatibility-lib/compatibility/mlist.rkt
@@ -208,3 +208,29 @@
      [(not (mpair? l)) #f]
      [(p? (mcar l)) (loop (mcdr l))]
      [else #f])))
+
+(define (mmandmap predicate? lst)
+  (cond
+    [(null? lst) #t]
+    [else
+     (if
+      (not (equal? (predicate? (mcar lst)) #t))
+              #f
+              (mmandmap predicate? (mcdr lst)))]))
+
+(define (mmormap predicate? lst)
+  (cond
+    [(null? lst) #f]
+    [else
+     (if
+      (equal? (predicate? (mcar lst)) #t)
+              #t
+              (mmormap predicate? (mcdr lst)))]))
+
+(define (mmremw v lst)
+  (cond
+    [(null? lst) null]
+    [(if (equal? (mcar lst) v)
+         (mmremw v (mcdr lst))
+         (mcons (mcar lst)
+               (mmremw v (mcdr lst))))]))

--- a/compatibility-lib/compatibility/mlist.rkt
+++ b/compatibility-lib/compatibility/mlist.rkt
@@ -22,7 +22,10 @@
          massoc
          mlist->list
          list->mlist
-         mlistof)
+         mlistof
+         mandmap
+         mormap
+         mremw)
 
 (begin-encourage-inline
  (define mmap
@@ -209,7 +212,7 @@
      [(p? (mcar l)) (loop (mcdr l))]
      [else #f])))
 
-(define (mmandmap predicate? lst)
+(define (mandmap predicate? lst)
   (cond
     [(null? lst) #t]
     [else
@@ -218,7 +221,7 @@
               #f
               (mmandmap predicate? (mcdr lst)))]))
 
-(define (mmormap predicate? lst)
+(define (mormap predicate? lst)
   (cond
     [(null? lst) #f]
     [else
@@ -227,7 +230,7 @@
               #t
               (mmormap predicate? (mcdr lst)))]))
 
-(define (mmremw v lst)
+(define (mremw v lst)
   (cond
     [(null? lst) null]
     [(if (equal? (mcar lst) v)


### PR DESCRIPTION
Added the following mlist functions:
- mandmap ([andmap](https://docs.racket-lang.org/reference/pairs.html#%28def._%28%28lib._racket%2Fprivate%2Fmap..rkt%29._andmap%29%29) equivalent for mlists)
- mormap ([ormap](https://docs.racket-lang.org/reference/pairs.html#%28def._%28%28lib._racket%2Fprivate%2Fmap..rkt%29._ormap%29%29) equivalent for mlists)
- mremw ([remw](https://docs.racket-lang.org/reference/pairs.html#%28def._%28%28lib._racket%2Fprivate%2Flist..rkt%29._remv%29%29) equivalent for mlists)

Made a test file in `compatibility-test/tests/racket` and updated the documention in `racket-doc/compatibility/scribblings/mlists.scrbl` accordingly